### PR TITLE
feat: adding user data persistancy when the page is reloads

### DIFF
--- a/src/hooks/useStoreUser.ts
+++ b/src/hooks/useStoreUser.ts
@@ -1,28 +1,36 @@
 import { create } from "zustand";
 import { UserProps, UserStore } from "@/types/UserProps";
+import { persist } from "zustand/middleware";
 
-const useStoreUser = create<UserStore>((set) => ({
-  user: {
-    userName: "",
-    userPhoto: "",
-    isAuthenticated: false,
-  },
-  setUser: (user: UserProps) =>
-    set(() => ({
-      user: {
-        userName: user.userName,
-        userPhoto: user.userPhoto,
-        isAuthenticated: true,
-      },
-    })),
-  resetStore: () =>
-    set(() => ({
+const useStoreUser = create<UserStore>()(
+  persist(
+    (set) => ({
       user: {
         userName: "",
         userPhoto: "",
         isAuthenticated: false,
       },
-    })),
-}));
+      setUser: (user: UserProps) =>
+        set(() => ({
+          user: {
+            userName: user.userName,
+            userPhoto: user.userPhoto,
+            isAuthenticated: true,
+          },
+        })),
+      resetStore: () =>
+        set(() => ({
+          user: {
+            userName: "",
+            userPhoto: "",
+            isAuthenticated: false,
+          },
+        })),
+    }),
+    {
+      name: "loginStore",
+    }
+  )
+);
 
 export default useStoreUser;


### PR DESCRIPTION
This pull request introduces a change to the `useStoreUser` hook in `src/hooks/useStoreUser.ts` to add persistence functionality using the `zustand` library's `persist` middleware. This ensures that the user state is stored and can persist across sessions.

State persistence:

* [`src/hooks/useStoreUser.ts`](diffhunk://#diff-7e72e140f15940b71b62e765ed3a4e1439ae8847914ddff0bb1925ec89581b09R3-R7): Integrated the `persist` middleware from `zustand` to the `useStoreUser` hook, enabling persistent storage of the user state under the key `loginStore`. [[1]](diffhunk://#diff-7e72e140f15940b71b62e765ed3a4e1439ae8847914ddff0bb1925ec89581b09R3-R7) [[2]](diffhunk://#diff-7e72e140f15940b71b62e765ed3a4e1439ae8847914ddff0bb1925ec89581b09L26-R34)