### PR TITLE
refactor: standardize API calls with centralized apiRequest service

### DIFF
--- a/src/app/artisan/components/ArtisanProfileCard.tsx
+++ b/src/app/artisan/components/ArtisanProfileCard.tsx
@@ -19,6 +19,7 @@ import { LuPencil } from "react-icons/lu";
 import { ArtisanProfile } from "@/types/Artisan";
 import useStoreUser from "@/hooks/useStoreUser";
 import { useRouter } from "next/navigation";
+import { artisanApi } from "@/services/api";
 
 const ArtisanProfileCard = () => {
   const [activeTab, setActiveTab] = useState<"produtos" | "avaliacoes">(
@@ -44,13 +45,7 @@ const ArtisanProfileCard = () => {
     const fetchArtisanProfile = async () => {
       try {
         setLoading(true);
-        const response = await fetch(`http://localhost:3333/artisan-profile/${userName}`);
-        
-        if (!response.ok) {
-          throw new Error('Artesão não encontrado');
-        }
-        
-        const data: ArtisanProfile = await response.json();
+        const data = await artisanApi.getProfile(userName);
         setArtisan(data);
 
         const loggedUserId = getLoggedUserId();
@@ -73,11 +68,16 @@ const ArtisanProfileCard = () => {
   }, [userName, user]);
 
   if (loading) {
-    return <div className="text-center py-8 text-gray-500 animate-spin">Carregando...</div>;
+    return (
+      <div className="text-center py-8">
+        <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-blue-500 rounded-full animate-spin"></div>
+        <p className="text-gray-500 mt-2">Carregando perfil...</p>
+      </div>
+    );
   }
 
   if (error || !artisan) {
-    return <div className="text-center py-8 text-gray-500">{error || "Artesão não encontrado."}</div>;
+    return <div className="text-center py-8 text-gray-500">{"Artesão não encontrado."}</div>;
   }
 
   const filteredReviews = artisan.userId

--- a/src/app/artisan/components/ProductArtisan.tsx
+++ b/src/app/artisan/components/ProductArtisan.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { BaseCard, ProductCardBody } from "@/components/Card";
 import { ApiProduct } from "@/types/product";
+import { productApi } from "@/services/api";
 
 function ProductArtisan({ artistId, visibleCount = 25, onTotalChange }: { artistId?: string, visibleCount?: number, onTotalChange?: (total: number) => void }) {
   const [products, setProducts] = useState<ApiProduct[]>([]);
@@ -9,23 +10,14 @@ function ProductArtisan({ artistId, visibleCount = 25, onTotalChange }: { artist
 
   useEffect(() => {
     const fetchProducts = async () => {
+      if (!artistId) {
+        setLoading(false);
+        return;
+      }
+
       try {
         setLoading(true);
-        const url = `http://localhost:3333/products/?artisanId=${artistId}`
-          
-        const response = await fetch(url, {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-        });
-
-        if (!response.ok) {
-          throw new Error('Erro ao carregar produtos');
-        }
-
-        const data: ApiProduct[] = await response.json();
+        const data = await productApi.getByArtisan(artistId);
         setProducts(data);
         
         if (onTotalChange) {

--- a/src/app/moderator/artisans/[id]/page.tsx
+++ b/src/app/moderator/artisans/[id]/page.tsx
@@ -12,91 +12,51 @@ import { Label } from "@/components/ui/label"
 import { IoIosArrowDown, IoIosInformationCircleOutline } from "react-icons/io"
 import { useState, useEffect } from "react"
 import { artisanDetails } from "@/types/artisanDetails"
-
+import { artisanApi } from "@/services/api"
 
 
 function Page() {
   const params = useParams();
-  const artisanId = params.id as unknown as number;
+  const artisanId = params.id as string;
   const [artisan, setArtisan] = useState<artisanDetails | null>(null);
   const router = useRouter()
 
   const fetchArtisans = async () => {
     try {
-      const response = await fetch(`http://localhost:3333/artisan-applications/${artisanId}`, {
-        method: 'GET',
-        headers: {
-          'Content-type': 'application/json',
-        },
-        credentials: 'include',
-      })
-
-      const result = await response.json();
-
-      if (response.status === 403) {
-        router.replace('/')
+      const result = await artisanApi.getApplication(artisanId);
+      setArtisan(result.artisanApplication);
+      console.log(result.artisanApplication);
+    } catch (error: any) {
+      if (error.message === "UNAUTHORIZED") {
+        router.replace('/');
       }
-
-      if (response.ok) {
-        setArtisan(result.artisanApplication)
-        console.log(result.artisanApplication)
-        console.log(artisan)
-      }
-
-    } catch (error) {
-
-      console.error('Erro ao buscar artesãos: ', error)
+      console.error('Erro ao buscar artesãos: ', error);
     }
   }
 
   useEffect(() => {
     fetchArtisans()
-  }, [])
+  }, [artisanId]);
 
   const handleApprove = async () => {
-
     try {
-      const response = await fetch(`http://localhost:3333/artisan-applications/${artisanId}/moderate`, {
-        method: 'POST',
-        headers: {
-          'Content-type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ status: 'APPROVED' })
-
-      })
-
-      if (response.ok) {
-        console.log(`artesao aprovado`)
-        router.push('/moderator/artisans')
-      } 
-
+      await artisanApi.approve(artisanId);
+      console.log(`artesao aprovado`);
+      router.push('/moderator/artisans');
     } catch (error) {
-      console.error('Erro ao aprovar artesão: ', error)
+      console.error('Erro ao aprovar artesão: ', error);
     }
   }
   
   const handleRejection = async () => {
     try {
-      const response = await fetch(`http://localhost:3333/artisan-applications/${artisanId}/moderate`, {
-        method: 'POST',
-        headers: {
-          'Content-type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ status: 'REJECTED' })
-
-      })
-
-      if (response.ok) {
-        console.log(`artesao aprovado`)
-        router.push('/moderator/artisans')
-      } 
+      await artisanApi.reject(artisanId);
+      console.log(`artesao rejeitado`);
+      router.push('/moderator/artisans');
     } catch (error) {
-      console.error('Erro ao aprovar artesão: ', error)
+      console.error('Erro ao rejeitar artesão: ', error);
     }
   }
-
 
   return (
     <div className='overflow-x-hidden'>

--- a/src/app/moderator/artisans/components/ModeratorTable.tsx
+++ b/src/app/moderator/artisans/components/ModeratorTable.tsx
@@ -7,6 +7,7 @@ import { LuPencil } from "react-icons/lu";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { artisanApi } from "@/services/api";
 
 type Artisan = {
   id: string;
@@ -51,51 +52,24 @@ function ModeratorTable({ searchTerm, activeFilter, artisans, onRefresh }: Moder
   }, [artisans, searchTerm, activeFilter]);
 
   const handleApprove = async (artisanId: string) => {
-
     try {
-      const response = await fetch(`http://localhost:3333/artisan-applications/${artisanId}/moderate`, {
-        method: 'POST',
-        headers: {
-          'Content-type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ status: 'APPROVED' })
-
-      })
-
-      if (response.ok) {
-        console.log(`artesao aprovado`)
-        // Atualiza a lista após aprovação
-        onRefresh()
-      } 
-
+      await artisanApi.approve(artisanId);
+      console.log(`artesão aprovado`);
+      onRefresh();
     } catch (error) {
-      console.error('Erro ao aprovar artesão: ', error)
+      console.error('Erro ao aprovar artesão: ', error);
     }
   }
   
   const handleRejection = async (artisanId: string) => {
     try {
-      const response = await fetch(`http://localhost:3333/artisan-applications/${artisanId}/moderate`, {
-        method: 'POST',
-        headers: {
-          'Content-type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify({ status: 'REJECTED' })
-
-      })
-
-      if (response.ok) {
-        console.log(`artesao rejeitado`)
-        // Atualiza a lista após rejeição
-        onRefresh()
-      } 
+      await artisanApi.reject(artisanId);
+      console.log(`artesão rejeitado`);
+      onRefresh();
     } catch (error) {
-      console.error('Erro ao rejeitar artesão: ', error)
+      console.error('Erro ao rejeitar artesão: ', error);
     }
   }
-
 
   return (
     <div>

--- a/src/app/moderator/artisans/page.tsx
+++ b/src/app/moderator/artisans/page.tsx
@@ -6,6 +6,7 @@ import ModeratorTitle from '../components/ModeratorTitle'
 import ModeratorSearch from './components/ModeratorSearch'
 import ModeratorTable from './components/ModeratorTable'
 import { useRouter } from 'next/navigation'
+import { artisanApi } from '@/services/api'
 
 type Artisan = {
   id: string;
@@ -25,32 +26,18 @@ function page() {
   const fetchArtisans = async () => {
     try {
       setIsLoading(true)
-      const response = await fetch('http://localhost:3333/artisan-applications', {
-        method: 'GET',
-        headers: {
-          'Content-type': 'application/json',
-        },
-        credentials: 'include',
-      })
-
-      if (response.status === 403) {
-        router.replace('/')
-        return
+      const result = await artisanApi.getApplications();
+      setArtisans(result.artisanApplications);
+      setIsAuthorized(true);
+    } catch (error: any) {
+      if (error.message === "UNAUTHORIZED") {
+        router.replace('/');
+        return;
       }
-
-      if (response.ok) {
-        const result = await response.json()
-        setArtisans(result.artisanApplications)
-        setIsAuthorized(true)
-      } else {
-        router.replace('/')
-      }
-
-    } catch (error) {
-      console.error('Erro ao buscar artesãos: ', error)
-      router.replace('/')
+      console.error('Erro ao buscar artesãos: ', error);
+      router.replace('/');
     } finally {
-      setIsLoading(false)
+      setIsLoading(false);
     }
   }
 

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -14,6 +14,7 @@ import Image from "next/image";
 import ProductSlide from "../components/ProductSlide";
 import { FormattedReview, ApiProduct  } from "@/types/product";
 import { GoArrowLeft } from "react-icons/go";
+import { productApi } from "@/services/api";
 
 const products = [
   {
@@ -92,15 +93,7 @@ function ProductPage() {
   const fetchProduct = async () => {
     try {
       setLoading(true);
-      const response = await fetch(
-        `http://localhost:3333/products/${productId}`
-      );
-
-      if (!response.ok) {
-        throw new Error("Produto não encontrado");
-      }
-
-      const productData: ApiProduct = await response.json();
+      const productData = await productApi.getById(productId);
       setProduct(productData);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Erro ao carregar produto");

--- a/src/components/AuthenticationModal/SignIn.tsx
+++ b/src/components/AuthenticationModal/SignIn.tsx
@@ -12,6 +12,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import useStoreUser from "@/hooks/useStoreUser";
 import { UserProps } from "@/types/UserProps";
+import { authApi } from "@/services/api";
 import Image from "next/image";
 
 const loginSchema = z.object({
@@ -55,33 +56,22 @@ function SignIn({
   const onSubmit = async (data: LoginFormData) => {
     setIsLoading(true);
     try {
-      const response = await fetch('http://localhost:3333/sessions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-        body: JSON.stringify(data),
-      });
-      const result = await response.json();
-
-      if (response.ok) {
-        const isModerator = result.roles.includes("MODERATOR") ? true : false;
-        const user: UserProps = {
-          userId: result.userId,
-          userName: result.name,
-          userPhoto: result.avatar,
-          isModerator: isModerator
-        }
-        setUser(user);
-        onSuccess();
-
-      } else {
-        const errorData = errorMessages[result.message];
-        setBackendError(errorData);
+      const result = await authApi.signIn(data);
+      
+      const isModerator = result.roles.includes("MODERATOR");
+      const user: UserProps = {
+        userId: result.userId,
+        userName: result.name,
+        userPhoto: result.avatar,
+        isModerator: isModerator
       }
-    } catch (errorData) {
-      console.error('Erro:', errorData);
+      setUser(user);
+      onSuccess();
+
+    } catch (error: any) {
+      const errorData = errorMessages[error.message] || 'Erro ao fazer login';
+      setBackendError(errorData);
+      console.error('Erro:', error);
     } finally {
       setIsLoading(false);
     }

--- a/src/components/AuthenticationModal/SignUpArtesian.tsx
+++ b/src/components/AuthenticationModal/SignUpArtesian.tsx
@@ -8,6 +8,7 @@ import SignInput from "@/components/AuthenticationModal/SignInput";
 import { Button } from "@/components/ui/button";
 import { FaExclamationTriangle, FaRegCalendarAlt } from "react-icons/fa";
 import { DialogTitle } from "@radix-ui/react-dialog";
+import { artisanApi } from "@/services/api";
 
 // Validação com Zod para artesão
 const artisanSchema = z.object({
@@ -52,7 +53,6 @@ async function traduzirErro(mensagem: string): Promise<string> {
 // Componente principal
 function ArtisanSignUpPage({
   children,
-  artisanId,
   onSuccess,
 }: {
   children: React.ReactNode;
@@ -74,63 +74,40 @@ function ArtisanSignUpPage({
     setTimeout(() => setUiError(null), 5000);
   };
 
-  // Função para criar artesão
   async function createArtisan(data: ArtisanData) {
     try {
-
-      const res = await fetch("http://localhost:3333/artisan-applications", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          rawMaterial: data.rawMaterial,
-          technique: data.technique,
-          finalityClassification: data.finalityClassification,
-          sicab: data.sicab,
-          sicabRegistrationDate: data.sicabRegistration,
-          sicabValidUntil: data.sicabValidity,
-        }),
+      await artisanApi.createApplication({
+        rawMaterial: data.rawMaterial,
+        technique: data.technique,
+        finalityClassification: data.finalityClassification,
+        sicab: data.sicab,
+        sicabRegistrationDate: data.sicabRegistration,
+        sicabValidUntil: data.sicabValidity,
       });
-
-      const contentType = res.headers.get("content-type");
-      let body = null;
-      if (contentType && contentType.includes("application/json")) {
-        body = await res.json();
-      } else {
-        body = await res.text();
-      }
-
-      if (!res.ok) {
-        if (res.status === 400 && body.errors) {
-          await Promise.all(
-            (
-              Object.entries(body.errors) as [keyof ArtisanData, string[]][]
-            ).map(async ([field, msgs]) => {
-              const msgTraduzida = await traduzirErro(msgs[0]);
-              setFormError(field as keyof ArtisanData, {
-                type: "server",
-                message: msgTraduzida,
-              });
-            })
-          );
-          return;
-        }
-        if (res.status === 409) {
-          await showUiError(body.message || "Usuário já existe.");
-          return;
-        }
-        await showUiError(body.message || "Erro ao criar usuário.");
-        return;
-      }
 
       await showUiError("sucesso: Artesão foi enviado para analise.");
       setTimeout(() => {
         onSuccess();
       }, 3000);
-    } catch (error) {
-      console.error("Erro ao criar artesão:", error);
+    } catch (error: any) {
+      if (error.status === 400 && error.errors) {
+        await Promise.all(
+          Object.entries(error.errors).map(async ([field, msgs]) => {
+            const messages = Array.isArray(msgs) ? msgs : [String(msgs)];
+            const msgTraduzida = await traduzirErro(messages[0]);
+            setFormError(field as keyof ArtisanData, {
+              type: "server",
+              message: msgTraduzida,
+            });
+          })
+        );
+        return;
+      }
+      if (error.status === 409) {
+        await showUiError(error.message || "Usuário já existe.");
+        return;
+      }
+      await showUiError(error.message || "Erro ao criar usuário.");
     }
   }
 

--- a/src/hooks/useSignUpLogic.ts
+++ b/src/hooks/useSignUpLogic.ts
@@ -1,8 +1,7 @@
 import { UserProps } from "@/types/UserProps";
 import { useCallback } from "react";
 import { SignUpData } from "../lib/schemas/signUpSchema";
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3333/users";
+import { authApi } from "@/services/api";
 
 async function traduzirErro(mensagem: string): Promise<string> {
   try {
@@ -34,70 +33,54 @@ export const useSignUpLogic = (
     setUiError(traduzida);
   }, [setUiError]);
 
-
   const createUser = useCallback(
     async (data: SignUpData): Promise<{success: boolean, userData?: any}> => {
-      const payload = {
-        name: data.name,
-        cpf: data.cpf,
-        email: data.email,
-        password: data.password,
-        birthDate: data.birthDate,
-        phone: `${data.codigoPais}${data.ddd}${data.phone}`,
-        ...(data.socialName &&
-          data.socialName.trim() !== "" && { socialName: data.socialName }),
-      };
-
       try {
-        const res = await fetch(`${API_URL}`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: 'include',
-          body: JSON.stringify(payload),
-        });
+        const payload = {
+          name: data.name,
+          cpf: data.cpf,
+          email: data.email,
+          password: data.password,
+          birthDate: data.birthDate,
+          phone: `${data.codigoPais}${data.ddd}${data.phone}`,
+          ...(data.socialName &&
+            data.socialName.trim() !== "" && { socialName: data.socialName }),
+        };
 
-        const body = await res.json();
-
-        if (!res.ok) {
-
-          if (res.status === 400 && body.errors) {
-            console.error("Validation errors detected");
-            return {
-              success: false
-            };
-          } else if (res.status === 409) {
-            const msgTraduzida = await traduzirErro(body.message);
-            await showUiError(msgTraduzida || "Usuário já existe.");
-            return{success: false};
-          }
-
-          await showUiError(body.message || "Erro ao criar usuário.");
-          return{success: false};
+        const body = await authApi.createUser(payload);
+        const isModerator = body.roles.includes("MODERATOR") ? true : false;
+  
+        if(data.isArtisan){
+          setUiError("Usuário criado! Complete o cadastro artesão.");
+  
+          return {
+            success: true,
+            userData: body,
+          };
         } else {
-          
-          const isModerator = body.roles.includes("MODERATOR") ? true : false;
-
-          if(data.isArtisan){
-            setUiError("Usuário criado! Complete o cadastro artesão.");
-
-            return {
-              success: true,
-              userData: body,
+            const user: UserProps = {
+              userId: body.userId,
+              userName: body.name,
+              userPhoto: body.avatar,
+              isModerator: isModerator
             };
-          } else {
-              const user: UserProps = {
-                userId: body.userId,
-                userName: body.name,
-                userPhoto: body.avatar,
-                isModerator: isModerator
-              };
-              setUser(user);
-              setUiError("Usuário criado e logado com sucesso!");
-
-              return { success: true };
-          }
+            setUser(user);
+            setUiError("Usuário criado e logado com sucesso!");
+  
+            return { success: true };
         }
       } catch (err: any) {
+        if (err.status === 400 && err.errors) {
+          console.error("Validation errors detected");
+          return {
+            success: false
+          };
+        } else if (err.status === 409) {
+          const msgTraduzida = await traduzirErro(err.message);
+          await showUiError(msgTraduzida || "Usuário já existe.");
+          return { success: false };
+        }
+  
         await showUiError(err.message || "Erro inesperado.");
         return { success: false };
       }

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -1,0 +1,111 @@
+import { apiRequest } from "../apiService";
+import { ApiProduct } from "@/types/product";
+import { ArtisanProfile } from "@/types/Artisan";
+import { artisanDetails } from "@/types/artisanDetails";
+
+type CreateUserPayload = {
+  name: string;
+  cpf: string;
+  email: string;
+  password: string;
+  birthDate: string;
+  phone: string;
+  socialName?: string;
+};
+
+type Artisan = {
+  id: string;
+  artisanName: string;
+  email: string;
+  status: "PENDING" | "APPROVED" | "REJECTED" | "INACTIVE";
+};
+
+type ArtisanApplicationPayload = {
+  rawMaterial: string;
+  technique: string;
+  finalityClassification: string;
+  sicab: string;
+  sicabRegistrationDate: string;
+  sicabValidUntil: string;
+};
+
+export const artisanApi = {
+  getProfile: (userName: string) =>
+    apiRequest<ArtisanProfile>(`/artisan-profile/${userName}`),
+
+  getApplications: () =>
+    apiRequest<{ artisanApplications: Artisan[] }>(`/artisan-applications`),
+
+  getApplication: (artisanId: string) =>
+    apiRequest<{ artisanApplication: artisanDetails }>(
+      `/artisan-applications/${artisanId}`
+    ),
+
+  createApplication: (data: ArtisanApplicationPayload) =>
+    apiRequest(`/artisan-applications`, {
+      method: "POST",
+      body: data,
+    }),
+
+  approve: (artisanId: string) =>
+    apiRequest(`/artisan-applications/${artisanId}/moderate`, {
+      method: "POST",
+      body: { status: "APPROVED" },
+    }),
+
+  reject: (artisanId: string) =>
+    apiRequest(`/artisan-applications/${artisanId}/moderate`, {
+      method: "POST",
+      body: { status: "REJECTED" },
+    }),
+};
+
+export const productApi = {
+  getByArtisan: (artisanId: string) =>
+    apiRequest<ApiProduct[]>(`/products/?artisanId=${artisanId}`),
+
+  getById: (id: string) => apiRequest<ApiProduct>(`/products/${id}`),
+
+  create: (productData: any) =>
+    apiRequest(`/products`, {
+      method: "POST",
+      body: productData,
+    }),
+};
+
+export const uploadApi = {
+  uploadFile: (file: File) => {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    return apiRequest<{ attachmentId: string; url?: string }>("/attachments", {
+      method: "POST",
+      body: formData,
+      isFormData: true,
+    });
+  },
+};
+
+export const authApi = {
+  createUser: (userData: CreateUserPayload) =>
+    apiRequest<{
+      userId: string;
+      name: string;
+      avatar: string;
+      roles: string[];
+    }>("/users", {
+      method: "POST",
+      body: userData,
+    }),
+
+  signIn: (credentials: { email: string; password: string }) =>
+    apiRequest<{
+      userId: string;
+      name: string;
+      avatar: string;
+      roles: string[];
+    }>("/sessions", {
+      method: "POST",
+      body: credentials,
+    }),
+};

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,40 +1,40 @@
 export interface Review {
-    reviewer: string;
-    rating: number;
-    reviewText: string;
-    reviewImages?: string[];
-    reviewerImage?: string;
+  reviewer: string;
+  rating: number;
+  reviewText: string;
+  reviewImages?: string[];
+  reviewerImage?: string;
 }
 
 export interface Product {
-    id?: number;
-    title: string;
-    price: number;
-    author: string;
-    description: string;
-    img: string;
-    reviews?: Review[]; 
+  id?: number;
+  title: string;
+  price: number;
+  author: string;
+  description: string;
+  img: string;
+  reviews?: Review[];
 }
 
 export interface FormattedReview {
-    reviewerImage?: string;
-    reviewerName: string;
-    rating: number;
-    reviewText: string;
-    reviewImages?: string[];
+  reviewerImage?: string;
+  reviewerName: string;
+  rating: number;
+  reviewText: string;
+  reviewImages?: string[];
 }
 
 export interface ApiProduct {
-    id: string;
-    authorName: string;
-    authorId: string;
-    title: string;
-    description: string;
-    priceInCents: number;
-    categoryId: number;
-    stock: number;
-    likesCount: number;
-    averageRating: number;
-    photos: string[];
-    coverPhoto: string;
-  }
+  id: string;
+  authorName: string;
+  authorId: string;
+  title: string;
+  description: string;
+  priceInCents: number;
+  categoryId: number;
+  stock: number;
+  likesCount: number;
+  averageRating: number;
+  photos: string[];
+  coverPhoto: string;
+}


### PR DESCRIPTION
- Replace all manual fetch calls with centralized apiRequest function
- Create unified API services (authApi, artisanApi, productApi)
- Implement consistent error handling across all components
- Add TypeScript types for API responses
- Configure environment variables for API base URL
- Update authentication flow to use new API structure
- Standardize moderator actions (approve/reject artisans)
- Refactor product fetching in artisan components
- Remove hardcoded URLs and duplicate request logic

Components updated:
- SignIn.tsx, useSignUpLogic.ts, SignUpArtesian.tsx
- ModeratorTable.tsx, /moderator/artisans pages
- ProductArtisan.tsx, ArtisanProfileCard.tsx

Breaking changes: None (internal refactoring only)