### PR TITLE
Refactor: simplify report name retrieval and update Report type structure

### DIFF
--- a/src/app/moderator/reports/page.tsx
+++ b/src/app/moderator/reports/page.tsx
@@ -27,7 +27,6 @@ function ReportsPage() {
         page: currentPage,
         limit: 15,
       });
-
       if (result && result.data && Array.isArray(result.data)) {
         setReports(result.data);
         setPagination(result.pagination);

--- a/src/components/features/moderator/reports/reports-table.tsx
+++ b/src/components/features/moderator/reports/reports-table.tsx
@@ -22,16 +22,6 @@ const REASON_TRANSLATIONS: Record<string, string> = {
   INAPPROPRIATE_CONTENT: 'Conteúdo Inapropriado',
 };
 
-function getReportedName(report: Report): string {
-  if (report.product) {
-    const productName = report.product.ProductEntity?.name;
-    const artisanName = report.product.ProductEntity?.artisan?.user?.name;
-    return productName || artisanName || 'Produto Desconhecido';
-  }
-
-  return 'Produto Desconhecido';
-}
-
 function StatusLabel({ isSolved }: { isSolved: boolean }) {
   if (isSolved) {
     return (
@@ -89,9 +79,7 @@ function ReportsTable({ reports, isLoading }: ReportsTableProps) {
                   </div>
                 </div>
                 <div className="grid grid-cols-2 md:grid-cols-3 items-center px-3 w-full">
-                  <p className="truncate text-left">
-                    {getReportedName(report)}
-                  </p>
+                  <p className="truncate text-left">{report.product.title}</p>
                   <p className="hidden md:inline text-center whitespace-nowrap truncate">
                     {REASON_TRANSLATIONS[report.reason] || report.reason}
                   </p>

--- a/src/types/moderator-report.ts
+++ b/src/types/moderator-report.ts
@@ -28,7 +28,9 @@ export interface Report {
   description: string;
   createdAt: Date | { _seconds: number; _nanoseconds: number };
   isSolved: boolean;
-  product: ReportedProduct | null;
+  product: {
+    title: string;
+  };
 }
 
 export type ReportFilterType = 'all' | 'product' | 'resolved';


### PR DESCRIPTION
This pull request simplifies how reported product information is handled and displayed in moderator reports. The main change is to the `Report` type and how product names are accessed and shown in the reports table, removing unnecessary complexity and streamlining the data structure.

**Type and Data Structure Updates:**

* Updated the `Report` interface in `moderator-report.ts` to replace the nested `ReportedProduct` object with a simple `product` object containing only a `title` property. This change removes the possibility of `product` being `null` and eliminates deep nesting.

**UI and Logic Simplification:**

* Removed the `getReportedName` helper function in `reports-table.tsx` since the product title can now be accessed directly from the `report.product.title` property.
* Updated the reports table to display the product title directly using `report.product.title` instead of calling the removed helper function.

**Minor Code Cleanup:**

* Removed an unnecessary blank line in the `ReportsPage` component's data fetching logic.…ture